### PR TITLE
Fix hot-reload for Docker

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "doc": "doc"
   },
   "scripts": {
-    "start": "set NODE_ENV=development && webpack-dev-server --host 0.0.0.0 --inline --hot --port=3000 --history-api-fallback",
+    "start": "set NODE_ENV=development && webpack-dev-server --host 0.0.0.0 --inline --hot --port=3000 --history-api-fallback --watch-poll",
     "build": "NODE_ENV=production webpack --define process.env.NODE_ENV='\"production\"' -p ",
     "lint": "eslint --ext js,jsx src && find ./src/ -iname \"*.scss\" -exec sass-lint -v -q {} +",
     "test": "NODE_ENV=test mocha --recursive --compilers js:babel-register --require ./misc/testSetup.js \"src/**/*.spec.js\" "

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -12,7 +12,6 @@ console.log(`MODE=${dev ? 'dev' : 'production'}`)
 
 function getEntrySources(sources) {
   if (dev) {
-    sources.push('webpack-dev-server/client?http://localhost:3000')
     sources.push('webpack/hot/only-dev-server')
   }
 


### PR DESCRIPTION
 - Removed the entry 'webpack-dev-server/client?http://localhost:3000' since the --inline switch is used
 - add --watch-poll switch (https://github.com/webpack/webpack-dev-server/issues/143#issuecomment-242909999)